### PR TITLE
Add include to locate ia_css_fw_pkg_release.h

### DIFF
--- a/drivers/media/pci/intel-ipu4/ipu4_bxtB0/Makefile
+++ b/drivers/media/pci/intel-ipu4/ipu4_bxtB0/Makefile
@@ -22,5 +22,6 @@ include $(srcpath)/$(src)/../Makefile.link
 include $(srcpath)/$(src)/../Makefile.common
 ccflags-y += -I$(srcpath)/$(src)/../../../../../include/
 ccflags-y += -I$(srcpath)/$(src)/../
+ccflags-y += -I$(srcpath)/$(src)/../ipu4_$(IPU_STEP)
 
 ccflags-y += -DPARAMETER_INTERFACE_V2


### PR DESCRIPTION
We're pulling these modules in the build of an Ubuntu kernel flavour; when building we get this error:
```
% make ubuntu modules -j1
[...]
cp -f ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4.c ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4.bxtB0.lnk.c
  CC [M]  ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4.bxtB0.lnk.o
cp -f ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-bus.c ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-bus.bxtB0.lnk.c
  CC [M]  ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-bus.bxtB0.lnk.o
ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-bus.bxtB0.lnk.c: In function ‘intel_ipu4_bus_add_device’:
ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-bus.bxtB0.lnk.c:377:29: warning: assignment discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  adev->dev.archdata.dma_ops = &intel_ipu4_dma_ops;
                             ^
cp -f ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-dma.c ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-dma.bxtB0.lnk.c
  CC [M]  ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-dma.bxtB0.lnk.o
cp -f ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-buttress.c ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-buttress.bxtB0.lnk.c
  CC [M]  ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-buttress.bxtB0.lnk.o
cp -f ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-trace.c ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-trace.bxtB0.lnk.c
  CC [M]  ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-trace.bxtB0.lnk.o
cp -f ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-cpd.c ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-cpd.bxtB0.lnk.c
  CC [M]  ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-cpd.bxtB0.lnk.o
ubuntu/intel-camera-drivers/drivers/media/pci/intel-ipu4/ipu4_bxtB0/../intel-ipu4-cpd.bxtB0.lnk.c:21:35: fatal error: ia_css_fw_pkg_release.h: No such file or directory
```

Proposed patch fixes the build for me

Thanks,
`-` Loïc Minier